### PR TITLE
Idempotency Guard Layer

### DIFF
--- a/src/cli/release-escrow.ts
+++ b/src/cli/release-escrow.ts
@@ -41,11 +41,11 @@ async function releaseEscrowFunds(options: ReleaseEscrowOptions) {
 				? "Test SDF Network ; September 2015"
 				: "Public Global Stellar Network ; September 2015",
 		};
-		
+
 		if (custodianPublicKey) {
 			configOptions.custodianPublicKey = custodianPublicKey;
 		}
-		
+
 		const config = Config.getInstance(configOptions);
 
 		const escrowService = new EscrowService(config);
@@ -63,17 +63,11 @@ async function releaseEscrowFunds(options: ReleaseEscrowOptions) {
 		console.log("⏳ Releasing escrow funds...");
 		const startTime = Date.now();
 
-		const releaseParams: any = {
-			escrowPublicKey,
-			encryptedSecret,
-			encryptionKey,
-			custodianPublicKey,
-		};
 		const releaseParams: import("../services/escrow.service.js").EscrowReleaseParams = {
 			escrowPublicKey,
 			encryptedSecret,
 		};
-		
+
 		if (encryptionKey) {
 			releaseParams.encryptionKey = encryptionKey;
 		}

--- a/src/escrow-refund.test.ts
+++ b/src/escrow-refund.test.ts
@@ -44,35 +44,27 @@ export async function testEscrowRefund() {
 		console.log(`   Refunded: ${refundResult.refunded}`);
 		console.log(`   Idempotent: ${refundResult.idempotent}\n`);
 
-		// Test 2: Idempotency check (balance now depleted – should throw)
+		// Test 2: Idempotency check - refund depleted account
 		console.log(
-			"📝 Test 2: Testing idempotency – refund depleted account (should throw)...",
+			"📝 Test 2: Testing idempotency – refund depleted account...",
 		);
-		try {
-			await escrowService.refundEscrowFunds({
-				escrowPublicKey: escrowAccount.publicKey,
-				encryptedSecret: escrowAccount.encryptedSecret,
-				encryptionKey,
-				ownerPublicKey,
-			});
-			console.log(
-				"❌ Should have thrown an idempotency error for depleted balance!",
-			);
-		} catch (error) {
-			const msg = error instanceof Error ? error.message : "Unknown error";
-			if (msg.includes("Idempotency error") || msg.includes("already depleted")) {
-				console.log(
-					"✅ Correctly threw idempotency error for depleted balance!",
-				);
-				console.log(`   Error: ${msg}\n`);
-			} else {
-				console.log(`✅ Correctly blocked second refund with error: ${msg}\n`);
-			}
+		const secondRefundResult = await escrowService.refundEscrowFunds({
+			escrowPublicKey: escrowAccount.publicKey,
+			encryptedSecret: escrowAccount.encryptedSecret,
+			encryptionKey,
+			ownerPublicKey,
+		});
+
+		if (secondRefundResult.successful && secondRefundResult.idempotent) {
+			console.log("✅ Correctly returned idempotent success response!");
+			console.log(`   Transaction Hash: ${secondRefundResult.txHash}\n`);
+		} else {
+			console.log("❌ Should have returned an idempotent success response!\n");
 		}
 
 		// Test 3: isEscrowRefunded helper
 		console.log("📝 Test 3: Testing isEscrowRefunded helper...");
-		const alreadyRefunded = escrowService.isEscrowRefunded(refundResult.txHash);
+		const alreadyRefunded = await escrowService.isEscrowRefunded(escrowAccount.publicKey);
 		if (alreadyRefunded) {
 			console.log(
 				"✅ isEscrowRefunded correctly returns true for processed refund!\n",

--- a/src/escrow-release.test.ts
+++ b/src/escrow-release.test.ts
@@ -1,4 +1,3 @@
-import { testEscrowRelease } from "./escrow.test.js";
 import { EscrowService } from "./services/escrow.service.js";
 import { Config } from "./config.js";
 
@@ -18,7 +17,7 @@ async function testEscrowRelease() {
 		horizonUrl: "https://horizon-testnet.stellar.org",
 		networkPassphrase: "Test SDF Network ; September 2015",
 	};
-	
+
 	if (custodianPublicKey) {
 		configOptions.custodianPublicKey = custodianPublicKey;
 	}

--- a/src/escrow.test.ts
+++ b/src/escrow.test.ts
@@ -136,9 +136,7 @@ async function testEscrowRelease() {
 		if (!custodianKey) {
 			throw new Error('CUSTODIAN_PUBLIC_KEY is required');
 		}
-			throw new Error("Custodian public key not configured");
-		}
-		
+
 		const releaseResult = await escrowService.releaseEscrowFunds({
 			escrowPublicKey: escrowAccount.publicKey,
 			encryptedSecret: escrowAccount.encryptedSecret,

--- a/src/services/escrow.service.ts
+++ b/src/services/escrow.service.ts
@@ -49,8 +49,6 @@ export class EscrowService {
 	private stellarService: StellarService;
 	private config: Config;
 	private networkGuard: NetworkGuard;
-	private releasedTransactions: Set<string> = new Set();
-	private refundedTransactions: Set<string> = new Set();
 
 	constructor(config?: Config, networkGuard?: NetworkGuard) {
 		this.config = config || Config.getInstance();
@@ -222,6 +220,52 @@ export class EscrowService {
 	}
 
 	/**
+	 * Checks if an escrow account has already released funds to the custodian
+	 * @returns The transaction hash if a release exists, null otherwise
+	 */
+	private async checkOnChainRelease(escrowPublicKey: string, custodianPublicKey: string): Promise<string | null> {
+		try {
+			const server = this.stellarService.getServer();
+			const payments = await server.payments().forAccount(escrowPublicKey).order('desc').limit(20).call();
+
+			for (const record of payments.records) {
+				if (
+					record.type === 'payment' &&
+					record.source_account === escrowPublicKey &&
+					(record as any).to === custodianPublicKey
+				) {
+					return record.transaction_hash;
+				}
+			}
+			return null;
+		} catch (error) {
+			console.warn(`Failed to check on-chain release history: ${error instanceof Error ? error.message : 'Unknown error'}`);
+			return null;
+		}
+	}
+
+	/**
+	 * Checks if an escrow account has already been refunded to the owner
+	 * @returns The transaction hash if a refund exists, null otherwise
+	 */
+	private async checkOnChainRefund(escrowPublicKey: string): Promise<string | null> {
+		try {
+			const server = this.stellarService.getServer();
+			const transactions = await server.transactions().forAccount(escrowPublicKey).order('desc').limit(20).call();
+
+			for (const record of transactions.records) {
+				if (record.memo === 'REFUND' && record.source_account === escrowPublicKey) {
+					return record.hash;
+				}
+			}
+			return null;
+		} catch (error) {
+			console.warn(`Failed to check on-chain refund history: ${error instanceof Error ? error.message : 'Unknown error'}`);
+			return null;
+		}
+	}
+
+	/**
 	 * Releases funds from escrow account to custodian
 	 * Enforces single-release rule with idempotency check
 	 */
@@ -256,13 +300,23 @@ export class EscrowService {
 					.filter((balance: any) => balance.asset_type === "native")
 					.map((balance: any) => balance.balance)[0] || "0";
 
-			// Calculate amount to release (all available XLM minus minimum reserve)
+			// Calculate amount to release (all available XLM minus minimum reserve minus tx fee)
 			const minimumReserve = "1.0"; // 1 XLM minimum reserve
+			const baseFee = 0.00001; // 100 stroops
 			const availableBalance = (
-				parseFloat(xlmBalance) - parseFloat(minimumReserve)
+				parseFloat(xlmBalance) - parseFloat(minimumReserve) - baseFee
 			).toFixed(7);
 
 			if (parseFloat(availableBalance) <= 0) {
+				const existingTxHash = await this.checkOnChainRelease(escrowPublicKey, custodianPublicKey);
+				if (existingTxHash) {
+					return {
+						txHash: existingTxHash,
+						successful: true,
+						released: false, // Already released
+					};
+				}
+
 				throw new Error(
 					"Insufficient funds in escrow account. Available balance must be greater than minimum reserve.",
 				);
@@ -277,25 +331,8 @@ export class EscrowService {
 				releaseAmount,
 			);
 
-			// Generate transaction hash for idempotency check
-			const txHash = transaction.hash().toString("hex");
-
-			// Idempotency check: ensure this escrow hasn't been released before
-			if (this.releasedTransactions.has(txHash)) {
-				return {
-					txHash,
-					successful: true,
-					released: false, // Already released
-				};
-			}
-
 			// Submit the transaction
 			const result = await this.stellarService.submitTransaction(transaction);
-
-			// Mark as released if successful
-			if (result.successful) {
-				this.releasedTransactions.add(txHash);
-			}
 
 			return {
 				txHash: result.hash,
@@ -345,14 +382,24 @@ export class EscrowService {
 					.filter((balance: any) => balance.asset_type === "native")
 					.map((balance: any) => balance.balance)[0] || "0";
 
-			// Minimum reserve required to keep the account open
+			// Minimum reserve required to keep the account open plus tx fee
 			const minimumReserve = "1.0"; // 1 XLM
+			const baseFee = 0.00001;
 			const availableBalance = (
-				parseFloat(xlmBalance) - parseFloat(minimumReserve)
+				parseFloat(xlmBalance) - parseFloat(minimumReserve) - baseFee
 			).toFixed(7);
 
 			// If the balance is already depleted this is a duplicate refund attempt
 			if (parseFloat(availableBalance) <= 0) {
+				const existingTxHash = await this.checkOnChainRefund(escrowPublicKey);
+				if (existingTxHash) {
+					return {
+						txHash: existingTxHash,
+						successful: true,
+						refunded: false,
+						idempotent: true,
+					};
+				}
 				throw new Error(
 					"Idempotency error: escrow account balance is already depleted. Refund has likely already been processed.",
 				);
@@ -379,26 +426,8 @@ export class EscrowService {
 			// Sign with the escrow account's secret key
 			transaction.sign(escrowKeypair);
 
-			// Generate deterministic transaction hash
-			const txHash = transaction.hash().toString("hex");
-
-			// Idempotency check: ensure this exact refund tx hasn't been submitted before
-			if (this.refundedTransactions.has(txHash)) {
-				return {
-					txHash,
-					successful: true,
-					refunded: false,
-					idempotent: true,
-				};
-			}
-
 			// Submit the refund transaction
 			const result = await this.stellarService.submitTransaction(transaction);
-
-			// Record the refund to prevent duplicates
-			if (result.successful) {
-				this.refundedTransactions.add(txHash);
-			}
 
 			return {
 				txHash: result.hash,
@@ -408,8 +437,7 @@ export class EscrowService {
 			};
 		} catch (error) {
 			throw new Error(
-				`Failed to refund escrow funds: ${
-					error instanceof Error ? error.message : "Unknown error"
+				`Failed to refund escrow funds: ${error instanceof Error ? error.message : "Unknown error"
 				}`,
 			);
 		}
@@ -418,15 +446,17 @@ export class EscrowService {
 	/**
 	 * Checks if an escrow account has already been refunded
 	 */
-	public isEscrowRefunded(txHash: string): boolean {
-		return this.refundedTransactions.has(txHash);
+	public async isEscrowRefunded(escrowPublicKey: string): Promise<boolean> {
+		const hash = await this.checkOnChainRefund(escrowPublicKey);
+		return !!hash;
 	}
 
 	/**
 	 * Checks if an escrow account has already been released
 	 */
-	public isEscrowReleased(txHash: string): boolean {
-		return this.releasedTransactions.has(txHash);
+	public async isEscrowReleased(escrowPublicKey: string, custodianPublicKey: string): Promise<boolean> {
+		const hash = await this.checkOnChainRelease(escrowPublicKey, custodianPublicKey);
+		return !!hash;
 	}
 
 	/**


### PR DESCRIPTION
closes #10 

## Description
This PR implements a robust on-chain idempotency guard layer for the [EscrowService](cci:2://file:///home/adedayo/devzone/projects/web3/petad-stellar/src/services/escrow.service.ts:47:0-481:1) to prevent double-spend scenarios and elegantly handle duplicate release/refund requests.

## Changes Included
*   **On-Chain Verification Methods:** Added [checkOnChainRelease](cci:1://file:///home/adedayo/devzone/projects/web3/petad-stellar/src/services/escrow.service.ts:221:1-244:2) and [checkOnChainRefund](cci:1://file:///home/adedayo/devzone/projects/web3/petad-stellar/src/services/escrow.service.ts:246:1-265:2) to [EscrowService](cci:2://file:///home/adedayo/devzone/projects/web3/petad-stellar/src/services/escrow.service.ts:47:0-481:1). These methods query the Stellar Horizon API (`server.payments()` and `server.transactions()`) to accurately discover if a release/refund has already successfully settled on the network.
*   **Idempotency Handling:** [releaseEscrowFunds](cci:1://file:///home/adedayo/devzone/projects/web3/petad-stellar/src/cli/release-escrow.ts:14:0-131:1) and [refundEscrowFunds](cci:1://file:///home/adedayo/devzone/projects/web3/petad-stellar/src/services/escrow.service.ts:348:1-443:2) now intercept empty account balances. Instead of immediately throwing an error, they verify the on-chain history. If the transaction was securely recorded in a previous call, they cleanly return `{ successful: true, released: false }` or `{ successful: true, refunded: false, idempotent: true }`.

## Testing
- Successfully ran `npm run test` and `npx tsc` with no compilation errors.
- Both individual testnet workflows (`npm run test-release` and `npm run test-refund`) execute and verify idempotency behavior cleanly against live Horizon nodes.
