### PR TITLE
feat(types): add DisputeParams and DisputeResult to escrow types

### DIFF
--- a/src/types/escrow.ts
+++ b/src/types/escrow.ts
@@ -80,3 +80,14 @@ export interface ReleaseResult {
   ledger: number;
   payments: ReleasedPayment[];
 }
+
+export interface DisputeParams {
+  escrowAccountId: string;
+}
+
+export interface DisputeResult {
+  accountId:        string;
+  pausedAt:         Date;
+  platformOnlyMode: true;
+  txHash:           string;
+}


### PR DESCRIPTION
Adds [DisputeParams](cci:2://file:///Users/petersdt/drip3/petad-stellar/src/types/escrow.ts:37:0-39:1) and [DisputeResult](cci:2://file:///Users/petersdt/drip3/petad-stellar/src/types/escrow.ts:41:0-46:1) interfaces to [src/types/escrow.ts](cci:7://file:///Users/petersdt/drip3/petad-stellar/src/types/escrow.ts:0:0-0:0).

- [DisputeParams](cci:2://file:///Users/petersdt/drip3/petad-stellar/src/types/escrow.ts:37:0-39:1) — input type for initiating a dispute (`escrowAccountId`)
- [DisputeResult](cci:2://file:///Users/petersdt/drip3/petad-stellar/src/types/escrow.ts:41:0-46:1) — result shape returned after a dispute is raised (`accountId`, `pausedAt`, `platformOnlyMode: true`, `txHash`)
- `EscrowStatus` enum was already in place; no changes needed

Part of the Types & Error Handling epic.

## Closes
close #39 