### PR TITLE
[#51] [SDK · Account management] Implement isValidAmount() validator

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `isValidAmount()` validator: validates positive Stellar amount strings with up to 7 decimal places and rejects scientific notation (`src/utils/validation.ts`)
 - `getMinimumReserve()` utility to calculate the minimum XLM balance required for an account based on signers, offers, and trustlines (`src/accounts/keypair.ts`)
 - `Percentage` branded type: compile-time guarantee that a number is validated to [0, 100] (`src/types/escrow.ts`)
 - `asPercentage()` runtime guard: validates and casts a number to `Percentage`, throws `RangeError` on NaN, Infinity, or out-of-range values (`src/types/escrow.ts`)

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -10,8 +10,13 @@ export function isValidSecretKey(key: string): boolean {
 
 export function isValidAmount(amount: string): boolean {
   if (!amount || typeof amount !== 'string') return false;
-  const num = parseFloat(amount);
-  return !isNaN(num) && num > 0 && /^\d+(\.\d{1,7})?$/.test(amount);
+
+  // Stellar amounts are plain decimal strings with up to 7 fractional digits.
+  // This also rejects scientific notation (e.g. "1e5").
+  if (!/^\d+(\.\d{1,7})?$/.test(amount)) return false;
+
+  const num = Number(amount);
+  return Number.isFinite(num) && num > 0;
 }
 
 export function isValidDistribution(

--- a/tests/unit/utils/validation.test.ts
+++ b/tests/unit/utils/validation.test.ts
@@ -25,9 +25,11 @@ describe('isValidSecretKey', () => {
 describe('isValidAmount', () => {
   it('accepts positive decimal', () => expect(isValidAmount('100.50')).toBe(true));
   it('accepts whole number',     () => expect(isValidAmount('500')).toBe(true));
+  it('accepts smallest 7dp value', () => expect(isValidAmount('0.0000001')).toBe(true));
   it('rejects zero',             () => expect(isValidAmount('0')).toBe(false));
   it('rejects negative',         () => expect(isValidAmount('-50')).toBe(false));
   it('rejects non-numeric',      () => expect(isValidAmount('abc')).toBe(false));
+  it('rejects scientific notation', () => expect(isValidAmount('1e5')).toBe(false));
   it('rejects empty string',     () => expect(isValidAmount('')).toBe(false));
 });
 


### PR DESCRIPTION
Closes #51

## What changed
- tightened `isValidAmount()` to require plain decimal format with up to 7 fractional digits
- explicitly rejects scientific notation while still enforcing positive amounts
- added unit tests for issue-specific amount cases (`0.0000001` true and `1e5` false)

## Verification
- npm run build
- npm test