### PR TITLE
feat: implement getEscrowBalance function

### DIFF
--- a/src/escrow/index.ts
+++ b/src/escrow/index.ts
@@ -1,3 +1,60 @@
+import { isValidPublicKey } from '../utils/validation';
+import { ValidationError, EscrowNotFoundError } from '../utils/errors';
+import { BalanceInfo } from '../types/network';
+
+export async function getEscrowBalance(
+  accountId: string,
+  horizonUrl: string,
+): Promise<BalanceInfo> {
+  // Validate the account ID
+  if (!isValidPublicKey(accountId)) {
+    throw new ValidationError('accountId', 'Invalid public key format');
+  }
+
+  try {
+    // Fetch account from Horizon
+    const response = await fetch(`${horizonUrl}/accounts/${accountId}`);
+
+    if (response.status === 404) {
+      throw new EscrowNotFoundError(accountId);
+    }
+
+    if (!response.ok) {
+      throw new Error(`Horizon error: ${response.statusText}`);
+    }
+
+    const account = await response.json() as {
+      balances: Array<{ balance: string; asset_type: string }>;
+      last_modified_ledger: number;
+    };
+
+    // Extract native (XLM) balance
+    const nativeBalance = account.balances.find(
+      (b) => b.asset_type === 'native',
+    );
+
+    if (!nativeBalance) {
+      // Account exists but has no XLM balance
+      return {
+        accountId,
+        balance: '0',
+        lastModifiedLedger: account.last_modified_ledger,
+      };
+    }
+
+    return {
+      accountId,
+      balance: nativeBalance.balance,
+      lastModifiedLedger: account.last_modified_ledger,
+    };
+  } catch (error) {
+    if (error instanceof EscrowNotFoundError || error instanceof ValidationError) {
+      throw error;
+    }
+    throw new Error(`Failed to fetch escrow balance: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createEscrowAccount(..._args: unknown[]): unknown { return undefined; }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,6 @@ export type { SDKConfig, KeypairResult, AccountInfo, BalanceInfo } from './types
 export type { SubmitResult, TransactionStatus } from './types/transaction';
 
 // 6. Standalone functions
-export { createEscrowAccount, lockCustodyFunds, anchorTrustHash, verifyEventHash } from './escrow';
+export { getEscrowBalance, createEscrowAccount, lockCustodyFunds, anchorTrustHash, verifyEventHash } from './escrow';
 export { buildMultisigTransaction } from './transactions';
 export { getMinimumReserve } from './accounts';

--- a/tests/unit/escrow/index.test.ts
+++ b/tests/unit/escrow/index.test.ts
@@ -1,16 +1,197 @@
 import {
+  getEscrowBalance,
   createEscrowAccount,
   lockCustodyFunds,
   anchorTrustHash,
   verifyEventHash,
 } from '../../../src/escrow';
+import { EscrowNotFoundError, ValidationError } from '../../../src/utils/errors';
+import { BalanceInfo } from '../../../src/types/network';
 
-describe('escrow module placeholders', () => {
-  it('exports callable placeholder functions', () => {
-    expect(createEscrowAccount()).toBeUndefined();
-    expect(lockCustodyFunds()).toBeUndefined();
-    expect(anchorTrustHash()).toBeUndefined();
-    expect(verifyEventHash()).toBeUndefined();
+const MOCK_HORIZON_URL = 'https://horizon-testnet.stellar.org';
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+describe('getEscrowBalance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('validation', () => {
+    it('throws ValidationError for invalid public key', async () => {
+      await expect(getEscrowBalance('invalid-key', MOCK_HORIZON_URL)).rejects.toThrow(
+        ValidationError,
+      );
+    });
+
+    it('throws ValidationError for empty string', async () => {
+      await expect(getEscrowBalance('', MOCK_HORIZON_URL)).rejects.toThrow(
+        ValidationError,
+      );
+    });
+
+    it('throws ValidationError for incorrect key format', async () => {
+      // Key starting with wrong letter
+      await expect(
+        getEscrowBalance(
+          'SINVALID1234567890123456789012345678901234567890123456789',
+          MOCK_HORIZON_URL,
+        ),
+      ).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe('happy path - funded account', () => {
+    it('returns BalanceInfo for account with native balance', async () => {
+      const validAccountId = 'GBRPYHIL2CI3WHZSRXUBXSMEGBMNQPU7HY3ZMTSPYDZPA46PHYUQJZQ2';
+      const balance = '1234.5000000';
+      const lastModifiedLedger = 42824530;
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: validAccountId,
+          account_id: validAccountId,
+          balances: [
+            {
+              balance,
+              asset_type: 'native',
+            },
+          ],
+          last_modified_ledger: lastModifiedLedger,
+        }),
+      });
+
+      const result: BalanceInfo = await getEscrowBalance(
+        validAccountId,
+        MOCK_HORIZON_URL,
+      );
+
+      expect(result).toEqual({
+        accountId: validAccountId,
+        balance,
+        lastModifiedLedger,
+      });
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${MOCK_HORIZON_URL}/accounts/${validAccountId}`,
+      );
+    });
+  });
+
+  describe('happy path - zero balance account', () => {
+    it('returns BalanceInfo with zero balance when native balance is absent', async () => {
+      const validAccountId = 'GBRPYHIL2CI3WHZSRXUBXSMEGBMNQPU7HY3ZMTSPYDZPA46PHYUQJZQ2';
+      const lastModifiedLedger = 42824530;
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: validAccountId,
+          account_id: validAccountId,
+          balances: [
+            {
+              balance: '100.0000000',
+              asset_code: 'USD',
+              asset_issuer: 'GBUQWP3BOUZX34ULNQG23RQ6F4BFXEUVSMEA37XPR5G4WSLLOON3XHU',
+              asset_type: 'credit_alphanum4',
+            },
+          ],
+          last_modified_ledger: lastModifiedLedger,
+        }),
+      });
+
+      const result: BalanceInfo = await getEscrowBalance(
+        validAccountId,
+        MOCK_HORIZON_URL,
+      );
+
+      expect(result).toEqual({
+        accountId: validAccountId,
+        balance: '0',
+        lastModifiedLedger,
+      });
+    });
+
+    it('returns BalanceInfo with zero balance when balances array is empty', async () => {
+      const validAccountId = 'GBRPYHIL2CI3WHZSRXUBXSMEGBMNQPU7HY3ZMTSPYDZPA46PHYUQJZQ2';
+      const lastModifiedLedger = 42824530;
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          id: validAccountId,
+          account_id: validAccountId,
+          balances: [],
+          last_modified_ledger: lastModifiedLedger,
+        }),
+      });
+
+      const result: BalanceInfo = await getEscrowBalance(
+        validAccountId,
+        MOCK_HORIZON_URL,
+      );
+
+      expect(result).toEqual({
+        accountId: validAccountId,
+        balance: '0',
+        lastModifiedLedger,
+      });
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws EscrowNotFoundError for 404 response', async () => {
+      const validAccountId = 'GBRPYHIL2CI3WHZSRXUBXSMEGBMNQPU7HY3ZMTSPYDZPA46PHYUQJZQ2';
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      await expect(
+        getEscrowBalance(validAccountId, MOCK_HORIZON_URL),
+      ).rejects.toThrow(EscrowNotFoundError);
+    });
+
+    it('throws error for non-404 HTTP errors', async () => {
+      const validAccountId = 'GBRPYHIL2CI3WHZSRXUBXSMEGBMNQPU7HY3ZMTSPYDZPA46PHYUQJZQ2';
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+      await expect(
+        getEscrowBalance(validAccountId, MOCK_HORIZON_URL),
+      ).rejects.toThrow('Horizon error: Internal Server Error');
+    });
+
+    it('throws error for network failure', async () => {
+      const validAccountId = 'GBRPYHIL2CI3WHZSRXUBXSMEGBMNQPU7HY3ZMTSPYDZPA46PHYUQJZQ2';
+
+      (global.fetch as jest.Mock).mockRejectedValueOnce(
+        new Error('Network unreachable'),
+      );
+
+      await expect(
+        getEscrowBalance(validAccountId, MOCK_HORIZON_URL),
+      ).rejects.toThrow('Failed to fetch escrow balance: Network unreachable');
+    });
+  });
+
+  describe('escrow module placeholders', () => {
+    it('exports callable placeholder functions', () => {
+      expect(createEscrowAccount()).toBeUndefined();
+      expect(lockCustodyFunds()).toBeUndefined();
+      expect(anchorTrustHash()).toBeUndefined();
+      expect(verifyEventHash()).toBeUndefined();
+    });
   });
 });
 


### PR DESCRIPTION
closes #83 

Quality Checks
✅ All 87 unit tests passing
✅ TypeScript compilation successful
✅ ESLint validation passed
✅ Type safety verified
Implements the escrow balance fetching feature for the escrow lifecycle epic.

Changes:
- Add getEscrowBalance() function to accept accountId and horizonUrl
- Validate accountId with isValidPublicKey()
- Fetch account from Horizon API
- Extract native (XLM) balance from balances array
- Return BalanceInfo: {accountId, balance, lastModifiedLedger}
- Throw EscrowNotFoundError on 404, ValidationError on invalid input
- Add comprehensive unit tests covering:
  - Funded account with native balance
  - Account with zero balance
  - Account not found (404) error
  - Invalid public key validation
  - Other Horizon errors
  - Network failures
- Export new function from SDK index

Labels: escrow, network, sdk
Size: XS (~2-4 hours)