### PR TITLE
Feat/escrow manager class

### DIFF
--- a/src/escrow/escrow-manager.ts
+++ b/src/escrow/escrow-manager.ts
@@ -1,0 +1,144 @@
+import { SdkError, ValidationError } from '../utils/errors';
+import { isValidPublicKey, isValidAmount } from '../utils/validation';
+import { EscrowStatus } from '../types/escrow';
+import type {
+  CreateEscrowParams,
+  EscrowAccount,
+  ReleaseParams,
+  ReleaseResult,
+  DisputeParams,
+  DisputeResult,
+} from '../types/escrow';
+import type { BalanceInfo } from '../types/network';
+import type { SubmitResult } from '../types/transaction';
+import type { EscrowManagerDeps } from './types';
+
+/**
+ * Orchestrates escrow lifecycle operations using injected dependencies.
+ * All Horizon interactions are delegated to the provided clients.
+ */
+export class EscrowManager {
+  private readonly deps: EscrowManagerDeps;
+
+  /**
+   * @param deps - Injected dependencies for account, transaction, and Horizon operations.
+   * @throws {ValidationError} If masterSecretKey is not provided.
+   */
+  constructor(deps: EscrowManagerDeps) {
+    if (!deps.masterSecretKey) {
+      throw new ValidationError('masterSecretKey', 'masterSecretKey is required');
+    }
+    this.deps = deps;
+  }
+
+  /**
+   * Create a new escrow account on the Stellar network.
+   * @param params - Escrow creation parameters.
+   * @returns The created escrow account details.
+   */
+  async createAccount(params: CreateEscrowParams): Promise<EscrowAccount> {
+    try {
+      return await this.deps.accountManager.createEscrowAccount(params);
+    } catch (err) {
+      throw this.wrap('createAccount', err);
+    }
+  }
+
+  /**
+   * Lock funds into an escrow account.
+   * @param escrowAccountId - Public key of the escrow account.
+   * @param amount - XLM amount to lock.
+   * @returns Transaction submission result.
+   * @throws {ValidationError} If escrowAccountId or amount is invalid.
+   */
+  async lockFunds(escrowAccountId: string, amount: string): Promise<SubmitResult> {
+    if (!isValidPublicKey(escrowAccountId)) {
+      throw new ValidationError('escrowAccountId', 'Invalid escrow account ID');
+    }
+    if (!isValidAmount(amount)) {
+      throw new ValidationError('amount', 'Invalid amount');
+    }
+    try {
+      return await this.deps.transactionManager.lockFunds(
+        escrowAccountId,
+        amount,
+        this.deps.masterSecretKey,
+      );
+    } catch (err) {
+      throw this.wrap('lockFunds', err);
+    }
+  }
+
+  /**
+   * Release escrowed funds according to the provided distribution.
+   * @param params - Release parameters including distribution.
+   * @returns Release transaction result.
+   */
+  async releaseFunds(params: ReleaseParams): Promise<ReleaseResult> {
+    try {
+      return await this.deps.transactionManager.releaseFunds(params, this.deps.masterSecretKey);
+    } catch (err) {
+      throw this.wrap('releaseFunds', err);
+    }
+  }
+
+  /**
+   * Flag an escrow as disputed, restricting further operations.
+   * @param params - Dispute parameters.
+   * @returns Dispute result with freeze details.
+   */
+  async handleDispute(params: DisputeParams): Promise<DisputeResult> {
+    try {
+      return await this.deps.transactionManager.handleDispute(params, this.deps.masterSecretKey);
+    } catch (err) {
+      throw this.wrap('handleDispute', err);
+    }
+  }
+
+  /**
+   * Retrieve the native XLM balance of an escrow account.
+   * @param escrowAccountId - Public key of the escrow account.
+   * @returns Balance information.
+   * @throws {ValidationError} If escrowAccountId is invalid.
+   */
+  async getBalance(escrowAccountId: string): Promise<BalanceInfo> {
+    if (!isValidPublicKey(escrowAccountId)) {
+      throw new ValidationError('escrowAccountId', 'Invalid escrow account ID');
+    }
+    try {
+      return await this.deps.horizonClient.getBalance(escrowAccountId);
+    } catch (err) {
+      throw this.wrap('getBalance', err);
+    }
+  }
+
+  /**
+   * Determine the current status of an escrow account.
+   * @param escrowAccountId - Public key of the escrow account.
+   * @returns Current escrow status.
+   * @throws {ValidationError} If escrowAccountId is invalid.
+   */
+  async getStatus(escrowAccountId: string): Promise<EscrowStatus> {
+    if (!isValidPublicKey(escrowAccountId)) {
+      throw new ValidationError('escrowAccountId', 'Invalid escrow account ID');
+    }
+    try {
+      const info = await this.deps.horizonClient.getAccountInfo(escrowAccountId);
+      if (!info.exists) return EscrowStatus.NOT_FOUND;
+      const balance = parseFloat(info.balance);
+      return balance > 0 ? EscrowStatus.FUNDED : EscrowStatus.CREATED;
+    } catch (err) {
+      throw this.wrap('getStatus', err);
+    }
+  }
+
+  /** Wrap non-SDK errors with a consistent error code. */
+  private wrap(method: string, err: unknown): SdkError {
+    if (err instanceof SdkError) return err;
+    const message = err instanceof Error ? err.message : String(err);
+    return new SdkError(
+      `EscrowManager.${method} failed: ${message}`,
+      'ESCROW_MANAGER_ERROR',
+    );
+  }
+}

--- a/src/escrow/index.ts
+++ b/src/escrow/index.ts
@@ -6,3 +6,11 @@ export function lockCustodyFunds(..._args: unknown[]): unknown { return undefine
 export function anchorTrustHash(..._args: unknown[]): unknown { return undefined; }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function verifyEventHash(..._args: unknown[]): unknown { return undefined; }
+
+export { EscrowManager } from './escrow-manager';
+export type {
+  EscrowManagerDeps,
+  IHorizonClient,
+  IAccountManager,
+  ITransactionManager,
+} from './types';

--- a/src/escrow/types.ts
+++ b/src/escrow/types.ts
@@ -1,0 +1,36 @@
+import type { AccountInfo, BalanceInfo } from '../types/network';
+import type {
+  CreateEscrowParams,
+  EscrowAccount,
+  DisputeParams,
+  DisputeResult,
+  ReleaseParams,
+  ReleaseResult,
+} from '../types/escrow';
+import type { SubmitResult } from '../types/transaction';
+
+/** Abstraction over Horizon API for read-only account queries. */
+export interface IHorizonClient {
+  getBalance(accountId: string): Promise<BalanceInfo>;
+  getAccountInfo(accountId: string): Promise<AccountInfo>;
+}
+
+/** Creates and configures Stellar escrow accounts. */
+export interface IAccountManager {
+  createEscrowAccount(params: CreateEscrowParams): Promise<EscrowAccount>;
+}
+
+/** Builds, signs, and submits escrow-related transactions. */
+export interface ITransactionManager {
+  lockFunds(escrowAccountId: string, amount: string, secretKey: string): Promise<SubmitResult>;
+  releaseFunds(params: ReleaseParams, secretKey: string): Promise<ReleaseResult>;
+  handleDispute(params: DisputeParams, secretKey: string): Promise<DisputeResult>;
+}
+
+/** Dependencies injected into the EscrowManager constructor. */
+export interface EscrowManagerDeps {
+  horizonClient: IHorizonClient;
+  accountManager: IAccountManager;
+  transactionManager: ITransactionManager;
+  masterSecretKey: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,11 @@ export type { SDKConfig, KeypairResult, AccountInfo, BalanceInfo } from './types
 // 5. Transaction types
 export type { SubmitResult, TransactionStatus } from './types/transaction';
 
-// 6. Standalone functions
+// 6. EscrowManager class
+export { EscrowManager } from './escrow';
+export type { EscrowManagerDeps, IHorizonClient, IAccountManager, ITransactionManager } from './escrow';
+
+// 7. Standalone functions
 export { createEscrowAccount, lockCustodyFunds, anchorTrustHash, verifyEventHash } from './escrow';
 export { buildMultisigTransaction } from './transactions';
 export { getMinimumReserve } from './accounts';

--- a/tests/unit/escrow/escrow-manager.test.ts
+++ b/tests/unit/escrow/escrow-manager.test.ts
@@ -1,0 +1,230 @@
+import { EscrowManager } from '../../../src/escrow/escrow-manager';
+import { ValidationError, SdkError } from '../../../src/utils/errors';
+import { EscrowStatus } from '../../../src/types/escrow';
+import type {
+  EscrowManagerDeps,
+  IHorizonClient,
+  IAccountManager,
+  ITransactionManager,
+} from '../../../src/escrow/types';
+
+const VALID_PUBLIC_KEY = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
+const VALID_SECRET_KEY = 'SABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVW';
+
+function createMockDeps(overrides: Partial<EscrowManagerDeps> = {}): EscrowManagerDeps {
+  const horizonClient: IHorizonClient = {
+    getBalance: jest.fn().mockResolvedValue({
+      accountId: VALID_PUBLIC_KEY,
+      balance: '100.0000000',
+      lastModifiedLedger: 1000,
+    }),
+    getAccountInfo: jest.fn().mockResolvedValue({
+      accountId: VALID_PUBLIC_KEY,
+      balance: '100.0000000',
+      signers: [],
+      thresholds: { low: 0, medium: 0, high: 0 },
+      sequenceNumber: '1',
+      exists: true,
+    }),
+  };
+
+  const accountManager: IAccountManager = {
+    createEscrowAccount: jest.fn().mockResolvedValue({
+      accountId: VALID_PUBLIC_KEY,
+      transactionHash: 'txhash123',
+      signers: [],
+      thresholds: { low: 0, medium: 0, high: 0 },
+    }),
+  };
+
+  const transactionManager: ITransactionManager = {
+    lockFunds: jest.fn().mockResolvedValue({
+      successful: true,
+      hash: 'lockhash123',
+      ledger: 5000,
+    }),
+    releaseFunds: jest.fn().mockResolvedValue({
+      successful: true,
+      txHash: 'releasehash123',
+      ledger: 5001,
+      payments: [],
+    }),
+    handleDispute: jest.fn().mockResolvedValue({
+      accountId: VALID_PUBLIC_KEY,
+      pausedAt: new Date(),
+      platformOnlyMode: true,
+      txHash: 'disputehash123',
+    }),
+  };
+
+  return {
+    horizonClient,
+    accountManager,
+    transactionManager,
+    masterSecretKey: VALID_SECRET_KEY,
+    ...overrides,
+  };
+}
+
+describe('EscrowManager', () => {
+  describe('constructor', () => {
+    it('creates an instance with valid deps', () => {
+      const manager = new EscrowManager(createMockDeps());
+      expect(manager).toBeInstanceOf(EscrowManager);
+    });
+
+    it('throws ValidationError when masterSecretKey is empty', () => {
+      expect(() => new EscrowManager(createMockDeps({ masterSecretKey: '' }))).toThrow(
+        ValidationError,
+      );
+    });
+  });
+
+  describe('createAccount', () => {
+    it('delegates to accountManager.createEscrowAccount', async () => {
+      const deps = createMockDeps();
+      const manager = new EscrowManager(deps);
+      const params = {
+        adopterPublicKey: VALID_PUBLIC_KEY,
+        ownerPublicKey: VALID_PUBLIC_KEY,
+        depositAmount: '100',
+      };
+      const result = await manager.createAccount(params);
+      expect(deps.accountManager.createEscrowAccount).toHaveBeenCalledWith(params);
+      expect(result.accountId).toBe(VALID_PUBLIC_KEY);
+    });
+
+    it('wraps non-SDK errors', async () => {
+      const deps = createMockDeps();
+      (deps.accountManager.createEscrowAccount as jest.Mock).mockRejectedValue(
+        new Error('network failure'),
+      );
+      const manager = new EscrowManager(deps);
+      await expect(
+        manager.createAccount({
+          adopterPublicKey: VALID_PUBLIC_KEY,
+          ownerPublicKey: VALID_PUBLIC_KEY,
+          depositAmount: '100',
+        }),
+      ).rejects.toThrow(SdkError);
+    });
+
+    it('passes through SdkError instances', async () => {
+      const deps = createMockDeps();
+      const sdkErr = new SdkError('already exists', 'DUPLICATE', false);
+      (deps.accountManager.createEscrowAccount as jest.Mock).mockRejectedValue(sdkErr);
+      const manager = new EscrowManager(deps);
+      await expect(
+        manager.createAccount({
+          adopterPublicKey: VALID_PUBLIC_KEY,
+          ownerPublicKey: VALID_PUBLIC_KEY,
+          depositAmount: '100',
+        }),
+      ).rejects.toBe(sdkErr);
+    });
+  });
+
+  describe('lockFunds', () => {
+    it('delegates to transactionManager.lockFunds with masterSecretKey', async () => {
+      const deps = createMockDeps();
+      const manager = new EscrowManager(deps);
+      await manager.lockFunds(VALID_PUBLIC_KEY, '50');
+      expect(deps.transactionManager.lockFunds).toHaveBeenCalledWith(
+        VALID_PUBLIC_KEY,
+        '50',
+        VALID_SECRET_KEY,
+      );
+    });
+
+    it('throws ValidationError for invalid escrowAccountId', async () => {
+      const manager = new EscrowManager(createMockDeps());
+      await expect(manager.lockFunds('invalid', '50')).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError for invalid amount', async () => {
+      const manager = new EscrowManager(createMockDeps());
+      await expect(manager.lockFunds(VALID_PUBLIC_KEY, '-1')).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe('releaseFunds', () => {
+    it('delegates to transactionManager.releaseFunds', async () => {
+      const deps = createMockDeps();
+      const manager = new EscrowManager(deps);
+      const params = { escrowAccountId: VALID_PUBLIC_KEY, distribution: [] };
+      await manager.releaseFunds(params);
+      expect(deps.transactionManager.releaseFunds).toHaveBeenCalledWith(params, VALID_SECRET_KEY);
+    });
+  });
+
+  describe('handleDispute', () => {
+    it('delegates to transactionManager.handleDispute', async () => {
+      const deps = createMockDeps();
+      const manager = new EscrowManager(deps);
+      const params = { escrowAccountId: VALID_PUBLIC_KEY };
+      await manager.handleDispute(params);
+      expect(deps.transactionManager.handleDispute).toHaveBeenCalledWith(
+        params,
+        VALID_SECRET_KEY,
+      );
+    });
+  });
+
+  describe('getBalance', () => {
+    it('delegates to horizonClient.getBalance', async () => {
+      const deps = createMockDeps();
+      const manager = new EscrowManager(deps);
+      const result = await manager.getBalance(VALID_PUBLIC_KEY);
+      expect(deps.horizonClient.getBalance).toHaveBeenCalledWith(VALID_PUBLIC_KEY);
+      expect(result.balance).toBe('100.0000000');
+    });
+
+    it('throws ValidationError for invalid escrowAccountId', async () => {
+      const manager = new EscrowManager(createMockDeps());
+      await expect(manager.getBalance('bad')).rejects.toThrow(ValidationError);
+    });
+  });
+
+  describe('getStatus', () => {
+    it('returns FUNDED when account exists with positive balance', async () => {
+      const manager = new EscrowManager(createMockDeps());
+      const status = await manager.getStatus(VALID_PUBLIC_KEY);
+      expect(status).toBe(EscrowStatus.FUNDED);
+    });
+
+    it('returns NOT_FOUND when account does not exist', async () => {
+      const deps = createMockDeps();
+      (deps.horizonClient.getAccountInfo as jest.Mock).mockResolvedValue({
+        accountId: VALID_PUBLIC_KEY,
+        balance: '0',
+        signers: [],
+        thresholds: { low: 0, medium: 0, high: 0 },
+        sequenceNumber: '0',
+        exists: false,
+      });
+      const manager = new EscrowManager(deps);
+      const status = await manager.getStatus(VALID_PUBLIC_KEY);
+      expect(status).toBe(EscrowStatus.NOT_FOUND);
+    });
+
+    it('returns CREATED when balance is zero', async () => {
+      const deps = createMockDeps();
+      (deps.horizonClient.getAccountInfo as jest.Mock).mockResolvedValue({
+        accountId: VALID_PUBLIC_KEY,
+        balance: '0',
+        signers: [],
+        thresholds: { low: 0, medium: 0, high: 0 },
+        sequenceNumber: '1',
+        exists: true,
+      });
+      const manager = new EscrowManager(deps);
+      const status = await manager.getStatus(VALID_PUBLIC_KEY);
+      expect(status).toBe(EscrowStatus.CREATED);
+    });
+
+    it('throws ValidationError for invalid escrowAccountId', async () => {
+      const manager = new EscrowManager(createMockDeps());
+      await expect(manager.getStatus('bad')).rejects.toThrow(ValidationError);
+    });
+  });
+});


### PR DESCRIPTION
Closes #85

## Summary

Implements the `EscrowManager` class that wires all escrow
lifecycle operations under a consistent dependency-injected interface.

## Root Cause

Escrow functions existed as standalone placeholders but had no unified
class providing a consistent interface, input validation, or error
handling contract for consumers of the SDK.

## Fix Implemented

- Added `IHorizonClient`, `IAccountManager`, `ITransactionManager`, and
  `EscrowManagerDeps` interfaces in `src/escrow/types.ts` for explicit
  dependency contracts.
- Implemented `EscrowManager` in `src/escrow/escrow-manager.ts`:
  - Constructor validates presence of `masterSecretKey`, throws
    `ValidationError` on missing value.
  - Exposes: `createAccount`, `lockFunds`, `releaseFunds`,
    `handleDispute`, `getBalance`, `getStatus` — all delegating to
    injected dependencies with no direct Horizon calls.
  - Input validation via `isValidPublicKey` / `isValidAmount` on
    methods that accept raw strings.
  - Private `wrap()` normalises unknown errors into `SdkError` with
    code `ESCROW_MANAGER_ERROR`; existing `SdkError` instances pass
    through unchanged.
  - JSDoc on every public method and the constructor.
- Exported `EscrowManager` and all three interfaces from
  `src/escrow/index.ts` and the SDK root (`src/index.ts`).

## Testing Performed

- Added `tests/unit/escrow/escrow-manager.test.ts` covering constructor
  validation, delegation to each injected dependency, input validation
  errors, non-SDK error wrapping, and `SdkError` pass-through.
- All 94 unit tests pass (`npm test`).
- Type-check passes (`npm run type-check`).
- Lint passes (`npm run lint`).

## CI Confirmation

Pipeline steps validated locally: lint → type-check → unit tests.

