### PR TITLE
[SDK · Escrow lifecycle] Implement releaseFunds() — payment operation…

### DIFF
--- a/src/escrow/index.ts
+++ b/src/escrow/index.ts
@@ -1,3 +1,72 @@
+import { Distribution } from '../types/escrow';
+import { PaymentOp } from '../types/transaction';
+
+const STROOPS_PER_XLM = 10_000_000n;
+const PERCENTAGE_SCALE = 10_000_000n;
+const PERCENTAGE_DENOMINATOR = 100n * PERCENTAGE_SCALE;
+
+function amountToStroops(amount: string): bigint {
+  const [wholePart, fractionalPart = ''] = amount.split('.');
+  const normalizedFraction = `${fractionalPart}0000000`.slice(0, 7);
+
+  return (
+    BigInt(wholePart || '0') * STROOPS_PER_XLM +
+    BigInt(normalizedFraction || '0')
+  );
+}
+
+function stroopsToAmount(stroops: bigint): string {
+  const whole = stroops / STROOPS_PER_XLM;
+  const fraction = (stroops % STROOPS_PER_XLM).toString().padStart(7, '0');
+  return `${whole.toString()}.${fraction}`;
+}
+
+function scalePercentage(percentage: number): bigint {
+  return BigInt(percentage.toFixed(7).replace('.', ''));
+}
+
+export function releaseFunds(
+  balance: string,
+  distribution: Distribution[],
+): PaymentOp[] {
+  const totalStroops = amountToStroops(balance);
+
+  const calculatedShares = distribution.map((entry, index) => {
+    const numerator = totalStroops * scalePercentage(entry.percentage);
+    return {
+      index,
+      recipient: entry.recipient,
+      baseStroops: numerator / PERCENTAGE_DENOMINATOR,
+      remainder: numerator % PERCENTAGE_DENOMINATOR,
+    };
+  });
+
+  const allocatedStroops = calculatedShares.reduce(
+    (sum, share) => sum + share.baseStroops,
+    0n,
+  );
+  let remainingStroops = totalStroops - allocatedStroops;
+
+  const bonusRecipients = [...calculatedShares].sort((left, right) => {
+    if (left.remainder === right.remainder) {
+      return left.index - right.index;
+    }
+    return left.remainder > right.remainder ? -1 : 1;
+  });
+
+  for (let i = 0; remainingStroops > 0n; i += 1) {
+    bonusRecipients[i].baseStroops += 1n;
+    remainingStroops -= 1n;
+  }
+
+  return calculatedShares.map(share => ({
+    type: 'Payment',
+    destination: share.recipient,
+    asset: 'XLM',
+    amount: stroopsToAmount(share.baseStroops),
+  }));
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createEscrowAccount(..._args: unknown[]): unknown { return undefined; }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,6 @@ export type { SDKConfig, KeypairResult, AccountInfo, BalanceInfo } from './types
 export type { SubmitResult, TransactionStatus } from './types/transaction';
 
 // 6. Standalone functions
-export { createEscrowAccount, lockCustodyFunds, anchorTrustHash, verifyEventHash } from './escrow';
+export { createEscrowAccount, lockCustodyFunds, anchorTrustHash, verifyEventHash, releaseFunds } from './escrow';
 export { buildMultisigTransaction } from './transactions';
 export { getMinimumReserve } from './accounts';

--- a/tests/unit/escrow/index.test.ts
+++ b/tests/unit/escrow/index.test.ts
@@ -3,7 +3,13 @@ import {
   lockCustodyFunds,
   anchorTrustHash,
   verifyEventHash,
+  releaseFunds,
 } from '../../../src/escrow';
+import { asPercentage } from '../../../src/types/escrow';
+
+const RECIPIENT_A = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const RECIPIENT_B = 'GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB7H';
+const RECIPIENT_C = 'GCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCD';
 
 describe('escrow module placeholders', () => {
   it('exports callable placeholder functions', () => {
@@ -11,6 +17,80 @@ describe('escrow module placeholders', () => {
     expect(lockCustodyFunds()).toBeUndefined();
     expect(anchorTrustHash()).toBeUndefined();
     expect(verifyEventHash()).toBeUndefined();
+  });
+});
+
+describe('releaseFunds', () => {
+  it('builds exact payment operations for a 60/40 split from 500 XLM', () => {
+    const operations = releaseFunds('500.0000000', [
+      { recipient: RECIPIENT_A, percentage: asPercentage(60) },
+      { recipient: RECIPIENT_B, percentage: asPercentage(40) },
+    ]);
+
+    expect(operations).toEqual([
+      {
+        type: 'Payment',
+        destination: RECIPIENT_A,
+        asset: 'XLM',
+        amount: '300.0000000',
+      },
+      {
+        type: 'Payment',
+        destination: RECIPIENT_B,
+        asset: 'XLM',
+        amount: '200.0000000',
+      },
+    ]);
+  });
+
+  it('builds a single payment when one recipient receives 100%', () => {
+    const operations = releaseFunds('500.0000000', [
+      { recipient: RECIPIENT_A, percentage: asPercentage(100) },
+    ]);
+
+    expect(operations).toEqual([
+      {
+        type: 'Payment',
+        destination: RECIPIENT_A,
+        asset: 'XLM',
+        amount: '500.0000000',
+      },
+    ]);
+  });
+
+  it('keeps a three-way split summed exactly to the original balance', () => {
+    const operations = releaseFunds('1.0000000', [
+      { recipient: RECIPIENT_A, percentage: asPercentage(33.3333333) },
+      { recipient: RECIPIENT_B, percentage: asPercentage(33.3333333) },
+      { recipient: RECIPIENT_C, percentage: asPercentage(33.3333334) },
+    ]);
+
+    expect(operations).toEqual([
+      {
+        type: 'Payment',
+        destination: RECIPIENT_A,
+        asset: 'XLM',
+        amount: '0.3333333',
+      },
+      {
+        type: 'Payment',
+        destination: RECIPIENT_B,
+        asset: 'XLM',
+        amount: '0.3333333',
+      },
+      {
+        type: 'Payment',
+        destination: RECIPIENT_C,
+        asset: 'XLM',
+        amount: '0.3333334',
+      },
+    ]);
+
+    const total = operations.reduce((sum, operation) => {
+      return sum + Number(operation.amount);
+    }, 0);
+
+    expect(total.toFixed(7)).toBe('1.0000000');
   });
 });
 


### PR DESCRIPTION
Close: #78

Implemented releaseFunds() in [src/escrow/index.ts] and re-exported it from [src/index.ts]

It now:

converts the balance to stroops and uses BigInt arithmetic for percentage math
builds one Payment operation per distribution entry
preserves exact 7-decimal formatting
distributes any leftover stroops by remainder so the split always sums back to the original balance
I also added unit coverage in [tests/unit/escrow/index.test.ts] 
for:

500 XLM with 60/40 => 300.0000000 and 200.0000000
100% to a single recipient
a three-way split that sums exactly to the starting balance
Verification: npm test -- --runInBand passed with 81/81 tests green.