### PR TITLE
feat(escrow): implement getEscrowStatus function with status checks a…

### DIFF
--- a/src/escrow/index.ts
+++ b/src/escrow/index.ts
@@ -1,3 +1,86 @@
+import Server from '@stellar/stellar-sdk';
+
+import { MIN_ACCOUNT_BALANCE_XLM, TESTNET_HORIZON_URL } from '../utils/constants';
+import { EscrowStatus } from '../types/escrow';
+import type { Signer, Thresholds } from '../types/escrow';
+
+function parseAmount(value: string): number {
+  const amount = Number(value);
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new RangeError(`Invalid amount: ${value}`);
+  }
+  return amount;
+}
+
+function getNativeBalance(balances: Array<{ asset_type: string; balance: string }>): number {
+  const nativeBalance = balances.find((balance) => balance.asset_type === 'native')?.balance;
+  const amount = Number(nativeBalance ?? '0');
+  return Number.isFinite(amount) ? amount : 0;
+}
+
+function isPlatformOnlyMode(signers: Signer[]): boolean {
+  const signersWithControl = signers.filter((signer) => signer.weight >= 2);
+  return signersWithControl.length === 1;
+}
+
+function isStandardThreeSignerConfig(signers: Signer[], thresholds: Thresholds): boolean {
+  const oneWeightSignerCount = signers.filter((signer) => signer.weight === 1).length;
+  return oneWeightSignerCount >= 3 && thresholds.high === 2;
+}
+
+function isNotFoundError(error: unknown): boolean {
+  if (error && typeof error === 'object') {
+    const maybeResponse = (error as Record<string, unknown>).response;
+    if (maybeResponse && typeof maybeResponse === 'object') {
+      return (maybeResponse as Record<string, unknown>).status === 404;
+    }
+
+    return (error as Record<string, unknown>).status === 404;
+  }
+  return false;
+}
+
+export async function getEscrowStatus(
+  escrowAccountId: string,
+  depositAmount: string,
+  horizonUrl = TESTNET_HORIZON_URL,
+): Promise<EscrowStatus> {
+  const server = new Server(horizonUrl);
+  const depositThreshold = parseAmount(depositAmount);
+
+  try {
+    const account = await server.loadAccount(escrowAccountId) as {
+      balances: Array<{ asset_type: string; balance: string }>;
+      signers: Signer[];
+      thresholds: Thresholds;
+    };
+
+    const nativeBalance = getNativeBalance(account.balances);
+    if (nativeBalance <= MIN_ACCOUNT_BALANCE_XLM) {
+      return EscrowStatus.SETTLED;
+    }
+
+    if (isPlatformOnlyMode(account.signers)) {
+      return EscrowStatus.DISPUTED;
+    }
+
+    if (nativeBalance >= depositThreshold && isStandardThreeSignerConfig(account.signers, account.thresholds)) {
+      return EscrowStatus.FUNDED;
+    }
+
+    if (nativeBalance < depositThreshold && isStandardThreeSignerConfig(account.signers, account.thresholds)) {
+      return EscrowStatus.SETTLING;
+    }
+
+    return EscrowStatus.CREATED;
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return EscrowStatus.NOT_FOUND;
+    }
+    throw error;
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createEscrowAccount(..._args: unknown[]): unknown { return undefined; }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,6 @@ export type { SDKConfig, KeypairResult, AccountInfo, BalanceInfo } from './types
 export type { SubmitResult, TransactionStatus } from './types/transaction';
 
 // 6. Standalone functions
-export { createEscrowAccount, lockCustodyFunds, anchorTrustHash, verifyEventHash } from './escrow';
+export { createEscrowAccount, lockCustodyFunds, anchorTrustHash, verifyEventHash, getEscrowStatus } from './escrow';
 export { buildMultisigTransaction } from './transactions';
 export { getMinimumReserve } from './accounts';

--- a/tests/unit/escrow/getEscrowStatus.test.ts
+++ b/tests/unit/escrow/getEscrowStatus.test.ts
@@ -1,0 +1,103 @@
+import { EscrowStatus } from '../../../src/types/escrow';
+import { getEscrowStatus } from '../../../src/escrow';
+
+const mockLoadAccount = jest.fn();
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    loadAccount: mockLoadAccount,
+  })),
+}));
+
+describe('getEscrowStatus', () => {
+  beforeEach(() => {
+    mockLoadAccount.mockReset();
+  });
+
+  function createAccountResponse(
+    balance: string,
+    signers: Array<{ publicKey: string; weight: number }>,
+    thresholds = { low: 1, medium: 2, high: 2 },
+  ) {
+    return {
+      balances: [{ asset_type: 'native', balance }],
+      signers,
+      thresholds,
+    };
+  }
+
+  it('returns NOT_FOUND when the account does not exist', async () => {
+    mockLoadAccount.mockRejectedValue({ response: { status: 404 } });
+
+    const status = await getEscrowStatus('GFAKE', '10');
+
+    expect(status).toBe(EscrowStatus.NOT_FOUND);
+  });
+
+  it('returns CREATED when account exists but has not hit deposit threshold and has no standard escrow signer configuration', async () => {
+    mockLoadAccount.mockResolvedValue(
+      createAccountResponse('1.5', [{ publicKey: 'G1', weight: 1 }], { low: 1, medium: 1, high: 1 }),
+    );
+
+    const status = await getEscrowStatus('GCREATED', '5');
+
+    expect(status).toBe(EscrowStatus.CREATED);
+  });
+
+  it('returns FUNDED when balance is above threshold and escrow has a standard 3-signer config', async () => {
+    mockLoadAccount.mockResolvedValue(
+      createAccountResponse('10', [
+        { publicKey: 'G1', weight: 1 },
+        { publicKey: 'G2', weight: 1 },
+        { publicKey: 'G3', weight: 1 },
+      ]),
+    );
+
+    const status = await getEscrowStatus('GFUNDED', '5');
+
+    expect(status).toBe(EscrowStatus.FUNDED);
+  });
+
+  it('returns DISPUTED when only one signer controls the account with weight >= 2', async () => {
+    mockLoadAccount.mockResolvedValue(
+      createAccountResponse('15', [
+        { publicKey: 'GPLATFORM', weight: 2 },
+        { publicKey: 'G1', weight: 1 },
+        { publicKey: 'G2', weight: 1 },
+      ]),
+    );
+
+    const status = await getEscrowStatus('GDISPUTED', '10');
+
+    expect(status).toBe(EscrowStatus.DISPUTED);
+  });
+
+  it('returns SETTLING when the account has a standard escrow signer config and is below deposit threshold', async () => {
+    mockLoadAccount.mockResolvedValue(
+      createAccountResponse('3', [
+        { publicKey: 'G1', weight: 1 },
+        { publicKey: 'G2', weight: 1 },
+        { publicKey: 'G3', weight: 1 },
+      ]),
+    );
+
+    const status = await getEscrowStatus('GSETTLING', '5');
+
+    expect(status).toBe(EscrowStatus.SETTLING);
+  });
+
+  it('returns SETTLED when the account balance is at or below the minimum reserve', async () => {
+    mockLoadAccount.mockResolvedValue(
+      createAccountResponse('1.0', [
+        { publicKey: 'G1', weight: 1 },
+        { publicKey: 'G2', weight: 1 },
+        { publicKey: 'G3', weight: 1 },
+      ]),
+    );
+
+    const status = await getEscrowStatus('GSETTLED', '5');
+
+    expect(status).toBe(EscrowStatus.SETTLED);
+  });
+});


### PR DESCRIPTION
Closes #84 


## Summary

This PR adds a new SDK helper that derives escrow status from on-chain Stellar account state, using Horizon account data and existing escrow conventions.

## What changed

- index.ts
  - Added `getEscrowStatus(escrowAccountId, depositAmount, horizonUrl?)`
  - Fetches account data from Horizon
  - Derives:
    - `NOT_FOUND` when Horizon returns 404
    - `SETTLED` when native balance is at or below minimum reserve
    - `DISPUTED` when only one signer has weight ≥ 2
    - `FUNDED` when balance ≥ deposit threshold with standard 3-signer config
    - `SETTLING` when balance < threshold with standard 3-signer config
    - `CREATED` for remaining valid escrow account states
- index.ts
  - Exported `getEscrowStatus` from public SDK entrypoint
- getEscrowStatus.test.ts
  - Added unit tests covering:
    - `NOT_FOUND`
    - `CREATED`
    - `FUNDED`
    - `DISPUTED`
    - `SETTLING`
    - `SETTLED`

## Testing

Run locally:

```bash
npm install
npm test -- --runInBand tests/unit/escrow/getEscrowStatus.test.ts
```

Expected result:
- `10` test suites passing
- `84` tests passing overall

## Notes

- This implementation uses `@stellar/stellar-sdk` Horizon account loading.
- The status logic is intentionally derived from on-chain balances, signer weights, and thresholds to match the escrow lifecycle requirements.