### PR TITLE
feat: implement buildPaymentOp() transaction helper — closes #112

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,5 +30,6 @@ export type { SubmitResult, TransactionStatus } from './types/transaction';
 
 // 6. Standalone functions
 export { createEscrowAccount, lockCustodyFunds, anchorTrustHash, verifyEventHash } from './escrow';
-export { buildMultisigTransaction } from './transactions';
+export { buildMultisigTransaction, buildPaymentOp } from './transactions';
+
 export { getMinimumReserve } from './accounts';

--- a/src/transactions/index.ts
+++ b/src/transactions/index.ts
@@ -1,2 +1,47 @@
+import { Asset, Operation } from '@stellar/stellar-sdk';
+import { isValidPublicKey, isValidAmount } from '../utils/validation';
+import { ValidationError } from '../utils/errors';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function buildMultisigTransaction(..._args: unknown[]): unknown { return undefined; }
+
+/**
+ * buildPaymentOp
+ *
+ * Builds a single Stellar payment operation ready to be added to a transaction.
+ *
+ * @param destination - Valid Stellar public key of the recipient
+ * @param amount      - Positive decimal string (max 7 decimal places)
+ * @param asset       - Stellar Asset object. Defaults to native XLM if omitted.
+ * @returns           - Stellar SDK Payment operation object
+ * @throws ValidationError if destination or amount is invalid
+ *
+ * @example
+ * const op = buildPaymentOp({
+ *   destination: 'GABC...XYZ',
+ *   amount: '10.5',
+ * });
+ */
+export function buildPaymentOp({
+  destination,
+  amount,
+  asset = Asset.native(),
+}: {
+  destination: string;
+  amount: string;
+  asset?: Asset;
+}): ReturnType<typeof Operation.payment> {
+  if (!isValidPublicKey(destination)) {
+    throw new ValidationError('destination', `Invalid Stellar public key: ${destination}`);
+  }
+
+  if (!isValidAmount(amount)) {
+    throw new ValidationError('amount', `Invalid amount: ${amount}. Must be a positive decimal string with up to 7 decimal places.`);
+  }
+
+  return Operation.payment({
+    destination,
+    asset,
+    amount,
+  });
+}

--- a/tests/unit/transactions/buildPaymentOp.test.ts
+++ b/tests/unit/transactions/buildPaymentOp.test.ts
@@ -1,0 +1,89 @@
+import { Asset, Operation } from '@stellar/stellar-sdk';
+import { buildPaymentOp } from '../../../src/transactions';
+import { ValidationError } from '../../../src/utils/errors';
+
+
+const VALID_DESTINATION = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+const VALID_AMOUNT = '10.5';
+
+describe('buildPaymentOp', () => {
+  it('returns a valid payment operation with native XLM by default', () => {
+    const op = buildPaymentOp({
+      destination: VALID_DESTINATION,
+      amount: VALID_AMOUNT,
+    });
+
+    const decoded = Operation.fromXDRObject(op);
+
+    expect(decoded).toBeDefined();
+    expect(decoded.type).toBe('payment');
+    expect((decoded as Operation.Payment).destination).toBe(VALID_DESTINATION);
+    expect((decoded as Operation.Payment).amount).toBe('10.5000000');
+    expect((decoded as Operation.Payment).asset.isNative()).toBe(true);
+  });
+
+  it('returns a payment operation with a custom asset', () => {
+    const usdc = new Asset(
+      'USDC',
+      'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+    );
+    const op = buildPaymentOp({
+      destination: VALID_DESTINATION,
+      amount: VALID_AMOUNT,
+      asset: usdc,
+    });
+
+    const decoded = Operation.fromXDRObject(op) as Operation.Payment;
+    expect(decoded.asset.code).toBe('USDC');
+    expect(decoded.asset.isNative()).toBe(false);
+  });
+
+  it('throws ValidationError for invalid destination', () => {
+    expect(() =>
+      buildPaymentOp({ destination: 'INVALID_KEY', amount: VALID_AMOUNT }),
+    ).toThrow(ValidationError);
+
+    expect(() =>
+      buildPaymentOp({ destination: 'INVALID_KEY', amount: VALID_AMOUNT }),
+    ).toThrow(/Invalid Stellar public key/);
+  });
+
+  it('throws ValidationError for empty destination', () => {
+    expect(() =>
+      buildPaymentOp({ destination: '', amount: VALID_AMOUNT }),
+    ).toThrow(ValidationError);
+  });
+
+  it('throws ValidationError for zero amount', () => {
+    expect(() =>
+      buildPaymentOp({ destination: VALID_DESTINATION, amount: '0' }),
+    ).toThrow(ValidationError);
+
+    expect(() =>
+      buildPaymentOp({ destination: VALID_DESTINATION, amount: '0' }),
+    ).toThrow(/Invalid amount/);
+  });
+
+  it('throws ValidationError for negative amount', () => {
+    expect(() =>
+      buildPaymentOp({ destination: VALID_DESTINATION, amount: '-5' }),
+    ).toThrow(ValidationError);
+  });
+
+  it('throws ValidationError for non-numeric amount', () => {
+    expect(() =>
+      buildPaymentOp({ destination: VALID_DESTINATION, amount: 'abc' }),
+    ).toThrow(ValidationError);
+  });
+
+  it('throws ValidationError for empty amount', () => {
+    expect(() =>
+      buildPaymentOp({ destination: VALID_DESTINATION, amount: '' }),
+    ).toThrow(ValidationError);
+  });
+
+  it('is exported from the public index', async () => {
+    const mod = await import('../../../src/index');
+    expect(mod.buildPaymentOp).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
Implements `buildPaymentOp()` helper for building XLM payment operations, closing #112.

## Changes
- **`src/transactions/index.ts`** — Added `buildPaymentOp()`
- **`src/index.ts`** — Exported `buildPaymentOp` from public surface
- **`tests/unit/transactions/buildPaymentOp.test.ts`** — 9 unit tests

## Usage
```ts
import { buildPaymentOp } from '@petad/stellar-sdk';

const op = buildPaymentOp({
  destination: 'GBBD...LA5',
  amount: '10.5',
});
```

## Tasks Completed
- [x] Accepts `destination`, `amount`, `asset` (default native XLM)
- [x] Validates destination with `isValidPublicKey()`
- [x] Validates amount with `isValidAmount()`
- [x] Returns Stellar SDK Payment operation object
- [x] Throws `ValidationError` for invalid inputs
- [x] Unit tests: valid payment op, invalid destination throws, zero amount throws

## Test Results
```
Tests: 87 passed, 87 total
Test Suites: 10 passed, 10 total
```

## Checklist
- [x] `npm test` passes
- [x] No new runtime dependencies
- [x] Narrowly scoped to described behavior