### PR TITLE
fix: implement EscrowManager with dependency-injected lifecycle deleg…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- `EscrowManager` class with dependency-injected escrow lifecycle methods: `createAccount`, `lockFunds`, `releaseFunds`, `handleDispute`, `getBalance`, and `getStatus` (`src/escrow/index.ts`)
+- Consistent escrow manager error wrapping for non-SDK errors using `ESCROW_MANAGER_ERROR` (`src/escrow/index.ts`)
+- Unit tests for escrow manager instantiation and method delegation (`tests/unit/escrow/escrowManager.test.ts`)
 - `getMinimumReserve()` utility to calculate the minimum XLM balance required for an account based on signers, offers, and trustlines (`src/accounts/keypair.ts`)
 - `Percentage` branded type: compile-time guarantee that a number is validated to [0, 100] (`src/types/escrow.ts`)
 - `asPercentage()` runtime guard: validates and casts a number to `Percentage`, throws `RangeError` on NaN, Infinity, or out-of-range values (`src/types/escrow.ts`)

--- a/src/escrow/index.ts
+++ b/src/escrow/index.ts
@@ -9,9 +9,19 @@ import {
   Transaction,
 } from '@stellar/stellar-sdk';
 
-import { CreateEscrowParams, EscrowAccount, Signer, Thresholds } from '../types/escrow';
+import {
+  CreateEscrowParams,
+  DisputeParams,
+  DisputeResult,
+  EscrowAccount,
+  EscrowStatus,
+  ReleaseParams,
+  ReleaseResult,
+  Signer,
+  Thresholds,
+} from '../types/escrow';
 import { getMinimumReserve } from '../accounts';
-import { ValidationError } from '../utils/errors';
+import { SdkError, ValidationError } from '../utils/errors';
 import { isValidPublicKey, isValidAmount } from '../utils/validation';
 
 import crypto from 'crypto';
@@ -32,6 +42,49 @@ export interface LockResult {
   conditionsHash: string;
   escrowPublicKey: string;
   transactionHash: string;
+}
+
+export interface EscrowHorizonClient {
+  loadAccount: (publicKey: string) => Promise<Account | { sequence: string }>;
+  submitTransaction: (tx: Transaction) => Promise<{ hash: string }>;
+}
+
+export interface EscrowAccountManager {
+  create: (args: {
+    publicKey: string;
+    startingBalance: string;
+  }) => Promise<{ accountId: string; transactionHash: string }>;
+  getBalance: (publicKey: string) => Promise<string>;
+}
+
+export interface EscrowTransactionManager {
+  releaseFunds: (
+    params: ReleaseParams,
+    context: {
+      horizonClient: EscrowHorizonClient;
+      masterSecretKey: string;
+    },
+  ) => Promise<ReleaseResult>;
+  handleDispute: (
+    params: DisputeParams,
+    context: {
+      horizonClient: EscrowHorizonClient;
+      masterSecretKey: string;
+    },
+  ) => Promise<DisputeResult>;
+  getStatus: (
+    escrowAccountId: string,
+    context: {
+      horizonClient: EscrowHorizonClient;
+    },
+  ) => Promise<EscrowStatus>;
+}
+
+export interface EscrowManagerDependencies {
+  horizonClient: EscrowHorizonClient;
+  accountManager: EscrowAccountManager;
+  transactionManager: EscrowTransactionManager;
+  masterSecretKey: string;
 }
 
 const MS_PER_DAY = 86_400_000;
@@ -228,4 +281,116 @@ export function anchorTrustHash(): undefined {
 
 export function verifyEventHash(): undefined {
   return undefined;
+}
+
+export class EscrowManager {
+  private readonly horizonClient: EscrowHorizonClient;
+
+  private readonly accountManager: EscrowAccountManager;
+
+  private readonly transactionManager: EscrowTransactionManager;
+
+  private readonly masterSecretKey: string;
+
+  /**
+   * Creates an escrow manager with injected dependencies.
+   */
+  constructor(dependencies: EscrowManagerDependencies) {
+    this.horizonClient = dependencies.horizonClient;
+    this.accountManager = dependencies.accountManager;
+    this.transactionManager = dependencies.transactionManager;
+    this.masterSecretKey = dependencies.masterSecretKey;
+  }
+
+  /**
+   * Creates a new escrow account and configures signer thresholds.
+   */
+  async createAccount(params: CreateEscrowParams): Promise<EscrowAccount> {
+    return this.executeWithErrorWrapping('createAccount', () =>
+      createEscrowAccount(params, this.accountManager),
+    );
+  }
+
+  /**
+   * Locks custody funds in escrow.
+   */
+  async lockFunds(
+    params: LockCustodyFundsParams,
+    networkPassphrase: string = Networks.TESTNET,
+  ): Promise<LockResult> {
+    return this.executeWithErrorWrapping('lockFunds', () =>
+      lockCustodyFunds(params, this.horizonClient, networkPassphrase),
+    );
+  }
+
+  /**
+   * Releases escrow funds using the configured transaction manager.
+   */
+  async releaseFunds(params: ReleaseParams): Promise<ReleaseResult> {
+    return this.executeWithErrorWrapping('releaseFunds', () =>
+      this.transactionManager.releaseFunds(params, {
+        horizonClient: this.horizonClient,
+        masterSecretKey: this.masterSecretKey,
+      }),
+    );
+  }
+
+  /**
+   * Applies dispute handling flow for an escrow account.
+   */
+  async handleDispute(params: DisputeParams): Promise<DisputeResult> {
+    return this.executeWithErrorWrapping('handleDispute', () =>
+      this.transactionManager.handleDispute(params, {
+        horizonClient: this.horizonClient,
+        masterSecretKey: this.masterSecretKey,
+      }),
+    );
+  }
+
+  /**
+   * Gets the XLM balance for an account.
+   */
+  async getBalance(publicKey: string): Promise<string> {
+    return this.executeWithErrorWrapping('getBalance', () =>
+      this.accountManager.getBalance(publicKey),
+    );
+  }
+
+  /**
+   * Retrieves the current escrow status.
+   */
+  async getStatus(escrowAccountId: string): Promise<EscrowStatus> {
+    return this.executeWithErrorWrapping('getStatus', () =>
+      this.transactionManager.getStatus(escrowAccountId, {
+        horizonClient: this.horizonClient,
+      }),
+    );
+  }
+
+  private async executeWithErrorWrapping<T>(
+    operation: string,
+    action: () => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await action();
+    } catch (error) {
+      throw this.wrapError(operation, error);
+    }
+  }
+
+  private wrapError(operation: string, error: unknown): SdkError {
+    if (error instanceof SdkError) {
+      return error;
+    }
+
+    if (error instanceof Error) {
+      return new SdkError(
+        `EscrowManager.${operation} failed: ${error.message}`,
+        'ESCROW_MANAGER_ERROR',
+        false,
+      );
+    }
+
+    return new SdkError(`EscrowManager.${operation} failed`, 'ESCROW_MANAGER_ERROR', false);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export {
   createEscrowAccount,
   calculateStartingBalance,
   lockCustodyFunds,
+  EscrowManager,
   anchorTrustHash,
   verifyEventHash,
 } from './escrow';

--- a/tests/unit/escrow/escrowManager.test.ts
+++ b/tests/unit/escrow/escrowManager.test.ts
@@ -1,0 +1,163 @@
+import { Account, Keypair } from '@stellar/stellar-sdk';
+
+import { EscrowStatus, asPercentage } from '../../../src/types/escrow';
+import { EscrowManager } from '../../../src/escrow';
+import { SdkError, ValidationError } from '../../../src/utils/errors';
+
+describe('EscrowManager', () => {
+  const sourceKeypair = Keypair.random();
+  const ownerPublicKey = Keypair.random().publicKey();
+  const adopterPublicKey = Keypair.random().publicKey();
+  const platformPublicKey = Keypair.random().publicKey();
+
+  const horizonClient = {
+    loadAccount: jest.fn(),
+    submitTransaction: jest.fn(),
+  };
+
+  const accountManager = {
+    create: jest.fn(),
+    getBalance: jest.fn(),
+  };
+
+  const transactionManager = {
+    releaseFunds: jest.fn(),
+    handleDispute: jest.fn(),
+    getStatus: jest.fn(),
+  };
+
+  const manager = new EscrowManager({
+    horizonClient,
+    accountManager,
+    transactionManager,
+    masterSecretKey: 'S_TEST_MASTER_SECRET',
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('instantiates successfully with injected dependencies', () => {
+    expect(manager).toBeInstanceOf(EscrowManager);
+  });
+
+  it('delegates createAccount using injected accountManager', async () => {
+    accountManager.create.mockResolvedValue({
+      accountId: 'GABC1234',
+      transactionHash: 'tx-create',
+    });
+
+    const result = await manager.createAccount({
+      adopterPublicKey,
+      ownerPublicKey,
+      depositAmount: '10',
+    });
+
+    expect(accountManager.create).toHaveBeenCalledWith({
+      publicKey: expect.any(String),
+      startingBalance: '12.5',
+    });
+    expect(result.accountId).toBe('GABC1234');
+    expect(result.transactionHash).toBe('tx-create');
+  });
+
+  it('delegates lockFunds using injected horizon client', async () => {
+    horizonClient.loadAccount.mockResolvedValue(new Account(sourceKeypair.publicKey(), '1'));
+    horizonClient.submitTransaction.mockResolvedValue({ hash: 'tx-lock' });
+
+    const result = await manager.lockFunds({
+      custodianPublicKey: adopterPublicKey,
+      ownerPublicKey,
+      platformPublicKey,
+      sourceKeypair,
+      depositAmount: '20',
+      durationDays: 2,
+    });
+
+    expect(horizonClient.loadAccount).toHaveBeenCalledWith(sourceKeypair.publicKey());
+    expect(horizonClient.submitTransaction).toHaveBeenCalledTimes(1);
+    expect(result.transactionHash).toBe('tx-lock');
+  });
+
+  it('delegates releaseFunds to transactionManager', async () => {
+    transactionManager.releaseFunds.mockResolvedValue({
+      successful: true,
+      txHash: 'tx-release',
+      ledger: 10,
+      payments: [{ recipient: ownerPublicKey, amount: '50' }],
+    });
+
+    const params = {
+      escrowAccountId: 'GESCROW123',
+      distribution: [{ recipient: ownerPublicKey, percentage: asPercentage(100) }],
+    };
+
+    const result = await manager.releaseFunds(params);
+
+    expect(transactionManager.releaseFunds).toHaveBeenCalledWith(params, {
+      horizonClient,
+      masterSecretKey: 'S_TEST_MASTER_SECRET',
+    });
+    expect(result.txHash).toBe('tx-release');
+  });
+
+  it('delegates handleDispute to transactionManager', async () => {
+    const disputeParams = { escrowAccountId: 'GESCROW123' };
+    transactionManager.handleDispute.mockResolvedValue({
+      accountId: 'GESCROW123',
+      pausedAt: new Date('2026-03-29T00:00:00.000Z'),
+      platformOnlyMode: true,
+      txHash: 'tx-dispute',
+    });
+
+    const result = await manager.handleDispute(disputeParams);
+
+    expect(transactionManager.handleDispute).toHaveBeenCalledWith(disputeParams, {
+      horizonClient,
+      masterSecretKey: 'S_TEST_MASTER_SECRET',
+    });
+    expect(result.txHash).toBe('tx-dispute');
+  });
+
+  it('delegates getBalance to accountManager', async () => {
+    accountManager.getBalance.mockResolvedValue('42.5');
+
+    const result = await manager.getBalance(ownerPublicKey);
+
+    expect(accountManager.getBalance).toHaveBeenCalledWith(ownerPublicKey);
+    expect(result).toBe('42.5');
+  });
+
+  it('delegates getStatus to transactionManager', async () => {
+    transactionManager.getStatus.mockResolvedValue(EscrowStatus.FUNDED);
+
+    const result = await manager.getStatus('GESCROW123');
+
+    expect(transactionManager.getStatus).toHaveBeenCalledWith('GESCROW123', {
+      horizonClient,
+    });
+    expect(result).toBe(EscrowStatus.FUNDED);
+  });
+
+  it('wraps non-SDK errors in a consistent SdkError', async () => {
+    transactionManager.releaseFunds.mockRejectedValue(new Error('network down'));
+
+    await expect(
+      manager.releaseFunds({
+        escrowAccountId: 'GESCROW123',
+        distribution: [{ recipient: ownerPublicKey, percentage: asPercentage(100) }],
+      }),
+    ).rejects.toMatchObject({
+      code: 'ESCROW_MANAGER_ERROR',
+      message: 'EscrowManager.releaseFunds failed: network down',
+    });
+  });
+
+  it('rethrows existing SDK errors without re-wrapping', async () => {
+    const validationError = new ValidationError('publicKey', 'invalid public key');
+    accountManager.getBalance.mockRejectedValue(validationError);
+
+    await expect(manager.getBalance('INVALID')).rejects.toBe(validationError);
+    await expect(manager.getBalance('INVALID')).rejects.toBeInstanceOf(SdkError);
+  });
+});


### PR DESCRIPTION
Closes #85

## Summary
Implements `EscrowManager` to provide a consistent escrow lifecycle interface and wire escrow operations through injected dependencies.

## Root Cause
The SDK exposed standalone escrow functions but lacked the required `EscrowManager` class and a unified lifecycle abstraction.

## Fix
Added `EscrowManager` with constructor injection for `horizonClient`, `accountManager`, `transactionManager`, and `masterSecretKey`, implementing:
- `createAccount`, `lockFunds`, `releaseFunds`, `handleDispute`, `getBalance`, and `getStatus`
- Manager-level consistent error wrapping across all methods
- JSDoc on all public methods
- Exported `EscrowManager` from the root SDK entry

## Testing
- ✅ Unit tests for `EscrowManager` instantiation and delegation across all public methods, including error wrapping behavior
- ✅ `test:cov` passes
- ✅ `lint` passes
- ✅ `type-check` passes
- ✅ `build` passes
