### PR TITLE
Feature/issue 33 lock funds types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export {
 } from './utils/errors';
 
 // 3. Escrow types (canonical source for Signer + Thresholds)
-export type { CreateEscrowParams, Signer, Thresholds, EscrowAccount, Distribution, ReleaseParams, ReleasedPayment, ReleaseResult, Percentage } from './types/escrow';
+export type { CreateEscrowParams, Signer, Thresholds, EscrowAccount, Distribution, ReleaseParams, ReleasedPayment, ReleaseResult, Percentage, LockFundsParams, LockResult } from './types/escrow';
 export { EscrowStatus, asPercentage } from './types/escrow';
 
 // 4. Network types (Signer + Thresholds excluded to avoid conflict)

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ export { EscrowStatus, asPercentage } from './types/escrow';
 export type { SDKConfig, KeypairResult, AccountInfo, BalanceInfo } from './types/network';
 
 // 5. Transaction types
-export type { SubmitResult, TransactionStatus } from './types/transaction';
+export type { SubmitResult, TransactionStatus, BuildParams, Operation } from './types/transaction';
 
 // 6. Standalone functions
 export { createEscrowAccount, lockCustodyFunds, anchorTrustHash, verifyEventHash } from './escrow';

--- a/src/types/escrow.ts
+++ b/src/types/escrow.ts
@@ -92,3 +92,28 @@ export interface DisputeResult {
   platformOnlyMode: true;
   txHash:           string;
 }
+
+// ---------------------------------------------------------------------------
+// Custody fund locking types (Issue #33)
+// ---------------------------------------------------------------------------
+
+/** Parameters required to lock funds under custodian control. */
+export interface LockFundsParams {
+  custodianPublicKey: string;
+  ownerPublicKey: string;
+  depositAmount: string;
+  durationDays: number;
+  conditions?: {
+    noViolations: boolean;
+    petReturned: boolean;
+  };
+}
+
+/** Result returned after custody funds are successfully locked. */
+export interface LockResult {
+  accountId: string;
+  lockedAmount: string;
+  unlockDate: Date;
+  conditionsHash: string;
+  transactionHash: string;
+}


### PR DESCRIPTION
 ## feat(types): LockFundsParams and LockResult — Issue #33

Closes #33 

  ### What was done

  Implemented the missing types for the custody fund locking operation as specified in issue #33.

  ### Changes

  **`src/types/escrow.ts`**
  - Added `LockFundsParams` interface with fields:
    - `custodianPublicKey: string`
    - `ownerPublicKey: string`
    - `depositAmount: string`
    - `durationDays: number`
    - `conditions?: { noViolations: boolean; petReturned: boolean }`
  - Added `LockResult` interface with fields:
    - `accountId: string`
    - `lockedAmount: string`
    - `unlockDate: Date`
    - `conditionsHash: string`
    - `transactionHash: string`

  **`src/index.ts`**
  - Exported `LockFundsParams` and `LockResult` from the root module so consumers of the SDK can import them directly.

  ### Verification
  - `tsc --noEmit` passes with no errors
  - No merge conflicts — branch was up to date with remote before changes